### PR TITLE
 Align structure data to intrinsic size (as for IDL)

### DIFF
--- a/src/dstructdesc.cpp
+++ b/src/dstructdesc.cpp
@@ -77,12 +77,13 @@ DStructDesc* FindInStructList(StructListT v, const string& s)
 
 void DUStructDesc::AddTag( const string& tagName, const BaseGDL* data)
 {
+  string TN = StrUpCase( tagName);  // prevent non-capitalized chars.
   for( SizeT i=0; i < tNames.size(); i++)
-    if( tNames[i] == tagName)
-      throw GDLException(tagName+" is already defined "
+    if( tNames[i] == TN)
+      throw GDLException(TN+" is already defined "
 			 "with a conflicting definition");
   
-  tNames.push_back(tagName);
+  tNames.push_back(  TN);
   Add( data->GetTag());
 }
 

--- a/src/dstructdesc.hpp
+++ b/src/dstructdesc.hpp
@@ -45,16 +45,38 @@ protected:
   // and DStringGDL (considers actual string sizes)
   SizeT nBytes = tags.back()->NBytes();
 
-  // alignment 
+//  2-May-2019 GVJ
+//  Align data in structures according to data lengthin accord with IDL).
+/********************
 #ifdef USE_EIGEN
+ (This forced all data to be aligned on 16-bytes.  There was no perceptible perfomance gain,
+ nor was any penalty found for simply using 2-byte alignment.
+
+  const int alignmentInBytes = 2; // there was no performance difference.
+
   assert( sizeof( char*) <= 16); 
   const int alignmentInBytes = 16; // set to multiple of 16 >= sizeof( char*)
 #else
   const int alignmentInBytes = sizeof( char*);
 #endif
+******************/
+
+  const int alignmentInBytes = sizeof( char*);
+
+// The old way:
+/******
   SizeT exceed = nBytes % alignmentInBytes;
   if( exceed > 0)
 	nBytes += alignmentInBytes - exceed;
+*****/
+// replacement:
+  SizeT Align = (nBytes < alignmentInBytes)? nBytes: alignmentInBytes;
+  SizeT initOffset = tagOffset.back();
+  SizeT Oddbytes = initOffset % Align;
+  if(Oddbytes > 0) { 
+	  tagOffset.pop_back();
+	  tagOffset.push_back( initOffset + (Align-Oddbytes));
+  }
 
   // valid tagOffset (used by NBytes())
   tagOffset.push_back( tagOffset.back() + nBytes);


### PR DESCRIPTION
 (in .cpp: And also convert attempts at lower-case structure elements. )